### PR TITLE
bugfix/display-correct-image

### DIFF
--- a/co-make/src/App.scss
+++ b/co-make/src/App.scss
@@ -720,7 +720,7 @@ p {
       width: 100%;
 
       img {
-        width: 90%;
+        width: 80%;
         border-radius: 6px;
         padding-top: 10px;
 
@@ -792,6 +792,7 @@ p {
     padding: 16px 2px;
     outline: none;
     font-size: 1.6rem;
+    padding-left: 20px;
 
     @media (max-width: 600px) {
       width: 60%;

--- a/co-make/src/components/add-post-form/AddPostForm.js
+++ b/co-make/src/components/add-post-form/AddPostForm.js
@@ -28,7 +28,7 @@ const AddPostForm = () => {
     if (isEditing) {
       setPostData({ ...postToEdit });
 
-      if (postToEdit.photo) {
+      if (postToEdit.photo !== "null") {
         setPhoto(postToEdit.photo);
       }
     }

--- a/co-make/src/components/authentication/Register.js
+++ b/co-make/src/components/authentication/Register.js
@@ -171,17 +171,9 @@ const Register = (props) => {
                   <p>
                     <span>
                       By signing up, you agree to CoMake's{" "}
-                      <a href="##" target="_blank">
-                        Terms of Service
-                      </a>
-                      ,{" "}
-                      <a href="##" target="_blank">
-                        Privacy Policy
-                      </a>{" "}
-                      <font>and</font>{" "}
-                      <a href="##" target="_blank">
-                        Cookie Policy
-                      </a>
+                      <a href="/register">Terms of Service</a>,{" "}
+                      <a href="/register">Privacy Policy</a> <font>and</font>{" "}
+                      <a href="/register">Cookie Policy</a>
                     </span>
                   </p>
                 </div>


### PR DESCRIPTION
Fixed a bug to display the correct image or no image if photo is null when editing a post.